### PR TITLE
fix measure_CO fromGM502B to GM702B

### DIFF
--- a/src/Multichannel_Gas_GMXXX.h
+++ b/src/Multichannel_Gas_GMXXX.h
@@ -70,7 +70,7 @@ class GAS_GMXXX {
     };
     uint32_t getGM502B();
     uint32_t measure_CO(){
-        return getGM502B();
+        return getGM702B();
     };
     uint32_t getGM702B();
     #ifdef GM_802B


### PR DESCRIPTION
Is sensor GM702B  for measuring CO ?  I fixed  measure_CO() to use GM702B from GM502B.